### PR TITLE
doc: fix example on connection with username

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ module.exports = {
             host: '127.0.0.1',
             port: 6379,
             db: 0,
-            user: 'username',
+            username: 'username',
             password: 'secret',
             // @see https://github.com/luin/ioredis#tls-options
             tls: { 


### PR DESCRIPTION
Connection prop is `username`, not `user` according to https://github.com/luin/ioredis/blob/v4/API.md#new-redisport-host-options